### PR TITLE
assert seems quite big compared to the small size of nanomorph

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const morph = require('./morph')
 
 module.exports = nanomorph
 
-// morph one tree into another tree
+// walk and morph one dom tree into another dom tree
 // (obj, obj) -> obj
 // no parent
 //   -> same: diff and walk children
@@ -15,11 +15,7 @@ module.exports = nanomorph
 //   -> diff nodes and apply patch to old node
 // nodes are the same
 //   -> walk all child nodes and append to old node
-function nanomorph (newTree, oldTree) { return walk(newTree, oldTree) }
-
-// walk and morph a dom tree
-// (obj, obj) -> obj
-function walk (newNode, oldNode) {
+function nanomorph (newNode, oldNode) {
   if (!oldNode) {
     return newNode
   } else if (!newNode) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const assert = require('assert')
 const morph = require('./morph')
 
 module.exports = nanomorph
@@ -16,12 +15,7 @@ module.exports = nanomorph
 //   -> diff nodes and apply patch to old node
 // nodes are the same
 //   -> walk all child nodes and append to old node
-function nanomorph (newTree, oldTree) {
-  assert.equal(typeof newTree, 'object', 'nanomorph: newTree should be an object')
-  assert.equal(typeof oldTree, 'object', 'nanomorph: oldTree should be an object')
-  const tree = walk(newTree, oldTree)
-  return tree
-}
+function nanomorph (newTree, oldTree) { return walk(newTree, oldTree) }
 
 // walk and morph a dom tree
 // (obj, obj) -> obj


### PR DESCRIPTION
Doesn't it pull in all of https://github.com/defunctzombie/commonjs-assert/blob/master/assert.js
...and all it seems to do is to check whether the arguments are objects, but the module description makes that obvious, so i thought maybe it's a good idea to remove it. ¯\_(ツ)_/¯
...or does all of this work differently?
