### PR TITLE
add failing test

### DIFF
--- a/morph.js
+++ b/morph.js
@@ -150,4 +150,3 @@ function removeAttributeNS (target, name, value, namespace) {
     target.removeAttributeNS(namespace, name)
   }
 }
-

--- a/test.js
+++ b/test.js
@@ -240,5 +240,22 @@ test('nanomorph', function (t) {
       tree = nanomorph(newTree, tree)
       t.equal(String(tree), expected, 'result was expected')
     })
+
+    t.test('should replace nodes after multiple iterations', function (t) {
+      t.plan(2)
+
+      var tree = html`<ul></ul>`
+      var newTree = html`<ul><li>1</li><li>2</li><li>3</li><li>4</li><li>5</li></ul>`
+      var expected = '<ul><li>1</li><li>2</li><li>3</li><li>4</li><li>5</li></ul>'
+
+      tree = nanomorph(newTree, tree)
+      t.equal(String(tree), expected, 'result was expected')
+
+      newTree = html`<ul><div>1</div><li>2</li><p>3</p><li>4</li><li>5</li></ul>`
+      expected = '<ul><div>1</div><li>2</li><p>3</p><li>4</li><li>5</li></ul>'
+
+      tree = nanomorph(newTree, tree)
+      t.equal(String(tree), expected, 'result was expected')
+    })
   })
 })


### PR DESCRIPTION
Adds a failing test for #6 - think this is our bug!

cc/ @kristoferjoseph @rreusser 

---

## Test Output
```txt
# should append nodes
ok 19 result was expected
# should remove nodes
ok 20 result was expected
# should mutate notes after multiple iterations
ok 21 result was expected
not ok 22 result was expected
  ---
    operator: equal
    expected: '<ul><div>1</div><li>2</li><p>3</p><li>4</li><li>5</li></ul>'
    actual:   '<ul></ul>'
    at: Test.<anonymous> (/Users/anon/src/yoshuawuyts/nanomorph/test.js:247:9)
  ...

1..22
# tests 22
# pass  21
# fail  1
```