### PR TITLE
always copy input values

### DIFF
--- a/lib/morph.js
+++ b/lib/morph.js
@@ -121,6 +121,9 @@ function updateInput (newNode, oldNode) {
   } else if (newValue !== oldValue) {
     oldNode.setAttribute('value', newValue)
     oldNode.value = newValue
+  } else {
+    // this is so elements like slider move their UI thingy
+    oldNode.value = newValue
   }
 }
 


### PR DESCRIPTION
This forces an update on the UI; for some reason we need to set a value, always. Derp.

Fixes https://github.com/yoshuawuyts/nanomorph/issues/48#issuecomment-287651313 which is a chrome implementation bug / web compat thing it seems. Ah well. 

cc/ @bcomnes 