### PR TITLE
morph onload tags on root

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 var assert = require('assert')
 var morph = require('./lib/morph')
+var rootLabelRegex = /^data-onloadid/
+
+var ELEMENT_NODE = 1
 
 module.exports = nanomorph
 
@@ -19,6 +22,8 @@ module.exports = nanomorph
 function nanomorph (oldTree, newTree) {
   assert.equal(typeof oldTree, 'object', 'nanomorph: oldTree should be an object')
   assert.equal(typeof newTree, 'object', 'nanomorph: newTree should be an object')
+
+  persistStatefulRoot(newTree, oldTree)
   var tree = walk(newTree, oldTree)
   return tree
 }
@@ -69,6 +74,20 @@ function updateChildren (newNode, oldNode) {
     } else if (retChildNode !== oldChildNode) {
       oldNode.replaceChild(retChildNode, oldChildNode)
       iNew--
+    }
+  }
+}
+
+function persistStatefulRoot (newNode, oldNode) {
+  if (!newNode || !oldNode || oldNode.nodeType !== ELEMENT_NODE || newNode.nodeType !== ELEMENT_NODE) return
+  var oldAttrs = oldNode.attributes
+  var attr, name
+  for (var i = 0, len = oldAttrs.length; i < len; i++) {
+    attr = oldAttrs[i]
+    name = attr.name
+    if (rootLabelRegex.test(name)) {
+      newNode.setAttribute(name, attr.value)
+      break
     }
   }
 }

--- a/test.js
+++ b/test.js
@@ -229,6 +229,29 @@ function abstractMorph (morph) {
   })
 }
 
+tape('should skip over data-onload attributes at root', function (t) {
+  var a = html`
+    <section data-onloadidzina="o0">
+      <input data-onloadidzina="o1">
+    </section>
+  `
+  var b = html`
+    <section>
+      <input autofocus="autofocus" value="" class="f6 normal">
+      <button class="bg-light-gray white ttu">save</button>
+    </section>
+  `
+  var c = html`
+    <section data-onloadidzina="o0">
+      <input autofocus="autofocus" value="" class="f6 normal">
+      <button class="bg-light-gray white ttu">save</button>
+    </section>
+  `
+  var d = nanomorph(a, b)
+  t.ok(c.isEqualNode(d), 'is equal')
+  t.end()
+})
+
 tape('chaos monkey #1', function (t) {
   var a, b
   a = html`<div r="r"><div></div></div>`


### PR DESCRIPTION
Makes it so `nanomorph` can be used to mutate `nanomorph` `._element` properties - this makes it so that the `onload` property of root is copied over.