### PR TITLE
Fix selected option being persisted from old node

### DIFF
--- a/lib/morph.js
+++ b/lib/morph.js
@@ -147,7 +147,7 @@ function updateTextarea (newNode, oldNode) {
 function updateSelect (newNode, oldNode) {
   if (!oldNode.hasAttributeNS(null, 'multiple')) {
     var i = 0
-    var curChild = oldNode.firstChild
+    var curChild = newNode.firstChild
     while (curChild) {
       var nodeName = curChild.nodeName
       if (nodeName && nodeName.toUpperCase() === 'OPTION') {

--- a/test.js
+++ b/test.js
@@ -195,7 +195,7 @@ function abstractMorph (morph) {
           </select>
         `
         var res = morph(a, b)
-        t.ok(res.children[1].hasAttributeNS(null, 'selected'))
+        t.equal(res.value, 'b', 'result was expected')
       })
     })
 

--- a/test.js
+++ b/test.js
@@ -179,6 +179,24 @@ function abstractMorph (morph) {
         var res = morph(a, b)
         t.equal(res.childNodes[0].data, 'FOMO')
       })
+
+      t.test('should update selected option', function (t) {
+        t.plan(1)
+        var a = html`
+          <select>
+            <option value="a" selected>a</option>
+            <option value="b">b</option>
+          </select>
+        `
+        var b = html`
+          <select>
+            <option value="a">a</option>
+            <option value="b" selected>b</option>
+          </select>
+        `
+        var res = morph(a, b)
+        t.ok(res.children[1].hasAttributeNS(null, 'selected'))
+      })
     })
 
     t.test('lists', function (t) {


### PR DESCRIPTION
I noticed that my select elements were reverting to their previous state. It turned out that the `selected` attribute of options would be persisted from the old node to the new one, which is in contrast to [how morphdom does it](https://github.com/patrick-steele-idem/morphdom/blob/43b808008bd39b571a1dd32d49811c7c22bd2021/src/specialElHandlers.js#L64).

This does enforce the author to always create nodes with the appropriate option being selected.