### PR TITLE
fix for node type select and add tests for select nodes

### DIFF
--- a/lib/morph.js
+++ b/lib/morph.js
@@ -26,7 +26,6 @@ function morph (newNode, oldNode) {
   if (nodeName === 'INPUT') updateInput(newNode, oldNode)
   else if (nodeName === 'OPTION') updateOption(newNode, oldNode)
   else if (nodeName === 'TEXTAREA') updateTextarea(newNode, oldNode)
-  else if (nodeName === 'SELECT') updateSelect(newNode, oldNode)
 
   copyEvents(newNode, oldNode)
 }
@@ -45,23 +44,24 @@ function copyAttrs (newNode, oldNode) {
     attrName = attr.name
     attrNamespaceURI = attr.namespaceURI
     attrValue = attr.value
-
     if (attrNamespaceURI) {
       attrName = attr.localName || attrName
       fromValue = oldNode.getAttributeNS(attrNamespaceURI, attrName)
-
       if (fromValue !== attrValue) {
         oldNode.setAttributeNS(attrNamespaceURI, attrName, attrValue)
       }
     } else {
-      fromValue = oldNode.getAttribute(attrName)
-
-      if (fromValue !== attrValue) {
-        // apparently values are always cast to strings, ah well
-        if (attrValue === 'null' || attrValue === 'undefined') {
-          oldNode.removeAttribute(attrName)
-        } else {
-          oldNode.setAttribute(attrName, attrValue)
+      if (!oldNode.hasAttribute(attrName)) {
+        oldNode.setAttribute(attrName, attrValue)
+      } else {
+        fromValue = oldNode.getAttribute(attrName)
+        if (fromValue !== attrValue) {
+          // apparently values are always cast to strings, ah well
+          if (attrValue === 'null' || attrValue === 'undefined') {
+            oldNode.removeAttribute(attrName)
+          } else {
+            oldNode.setAttribute(attrName, attrValue)
+          }
         }
       }
     }
@@ -144,30 +144,13 @@ function updateTextarea (newNode, oldNode) {
   }
 }
 
-function updateSelect (newNode, oldNode) {
-  if (!oldNode.hasAttributeNS(null, 'multiple')) {
-    var i = 0
-    var curChild = oldNode.firstChild
-    while (curChild) {
-      var nodeName = curChild.nodeName
-      if (nodeName && nodeName.toUpperCase() === 'OPTION') {
-        if (curChild.hasAttributeNS(null, 'selected')) break
-        i++
-      }
-      curChild = curChild.nextSibling
-    }
-
-    newNode.selectedIndex = i
-  }
-}
-
 function updateAttribute (newNode, oldNode, name) {
   if (newNode[name] !== oldNode[name]) {
     oldNode[name] = newNode[name]
     if (newNode[name]) {
       oldNode.setAttribute(name, '')
     } else {
-      oldNode.removeAttribute(name, '')
+      oldNode.removeAttribute(name)
     }
   }
 }

--- a/test.js
+++ b/test.js
@@ -201,6 +201,71 @@ function abstractMorph (morph) {
       })
     })
 
+    t.test('selectables', function (t) {
+      t.test('should append nodes', function (t) {
+        t.plan(1)
+        var a = html`<select></select>`
+        var b = html`<select><option>1</option><option>2</option><option>3</option><option>4</option></select>`
+        var expected = b.outerHTML
+        var res = morph(a, b)
+        t.equal(res.outerHTML, expected, 'result was expected')
+      })
+
+      t.test('should append nodes (including optgroups)', function (t) {
+        t.plan(1)
+        var a = html`<select></select>`
+        var b = html`<select><optgroup><option>1</option><option>2</option></optgroup><option>3</option><option>4</option></select>`
+        var expected = b.outerHTML
+        var res = morph(a, b)
+        t.equal(res.outerHTML, expected, 'result was expected')
+      })
+
+      t.test('should remove nodes', function (t) {
+        t.plan(1)
+        var a = html`<select><option>1</option><option>2</option><option>3</option><option>4</option></select>`
+        var b = html`<select></select>`
+        var expected = b.outerHTML
+        var res = morph(a, b)
+        t.equal(res.outerHTML, expected, 'result was expected')
+      })
+
+      t.test('should remove nodes (including optgroups)', function (t) {
+        t.plan(1)
+        var a = html`<select><optgroup><option>1</option><option>2</option></optgroup><option>3</option><option>4</option></select>`
+        var b = html`<select></select>`
+        var expected = b.outerHTML
+        var res = morph(a, b)
+        t.equal(res.outerHTML, expected, 'result was expected')
+      })
+
+      t.test('should add selected', function (t) {
+        t.plan(1)
+        var a = html`<select><option>1</option><option>2</option></select>`
+        var b = html`<select><option>1</option><option selected>2</option></select>`
+        var expected = b.outerHTML
+        var res = morph(a, b)
+        t.equal(res.outerHTML, expected, 'result was expected')
+      })
+
+      t.test('should add selected (xhtml)', function (t) {
+        t.plan(1)
+        var a = html`<select><option>1</option><option>2</option></select>`
+        var b = html`<select><option>1</option><option selected="selected">2</option></select>`
+        var expected = b.outerHTML
+        var res = morph(a, b)
+        t.equal(res.outerHTML, expected, 'result was expected')
+      })
+
+      t.test('should switch selected', function (t) {
+        t.plan(1)
+        var a = html`<select><option selected="selected">1</option><option>2</option></select>`
+        var b = html`<select><option>1</option><option selected="selected">2</option></select>`
+        var expected = b.outerHTML
+        var res = morph(a, b)
+        t.equal(res.outerHTML, expected, 'result was expected')
+      })
+    })
+
     t.test('should replace nodes', function (t) {
       t.plan(1)
       var a = html`<ul><li>1</li><li>2</li><li>3</li><li>4</li><li>5</li></ul>`


### PR DESCRIPTION
Hi, first Pull Request ever *whoo*
this pull request does the following:

1.  in "copyAttrs" i added a .hasAttributes check before getting the attributes from the oldNode,
because getAttributes returns null or "" on not existing attributes (*1), so the "if" (*2) on Line 60 will be true even on existing attributes 
2. remove the special case for "SELECT" Nodes, because Attributes will now set in copyAttrs
3. add tests for select nodes

*1 https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttribute
*2 https://github.com/moszeed/nanomorph/blob/1d5b893f2b05966deeb6679ab7f2edb6e042ce84/lib/morph.js#L60