### PR TITLE
add strict equality checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,8 @@ function walk (newNode, oldNode) {
     return newNode
   } else if (!newNode) {
     return null
+  } else if (newNode === oldNode) {
+    return oldNode
   } else if (newNode.isSameNode && newNode.isSameNode(oldNode)) {
     return oldNode
   } else if (newNode.tagName !== oldNode.tagName) {

--- a/test.js
+++ b/test.js
@@ -157,6 +157,23 @@ function abstractMorph (morph) {
       })
     })
 
+    t.test('strict equality', function (t) {
+      t.test('should return a if true', function (t) {
+        t.plan(1)
+        var a = html`<div>YOLO</div>`
+        var res = morph(a, a)
+        t.equal(res.childNodes[0].data, 'YOLO')
+      })
+
+      t.test('should return b if false', function (t) {
+        t.plan(1)
+        var a = html`<div>YOLO</div>`
+        var b = html`<div>FOMO</div>`
+        var res = morph(a, b)
+        t.equal(res.childNodes[0].data, 'FOMO')
+      })
+    })
+
     t.test('isSameNode', function (t) {
       t.test('should return a if true', function (t) {
         t.plan(1)


### PR DESCRIPTION
Adding another flavor for checking if nodes are the same. This looks like a safe option to add and I'm currently investigating if it isn't even more useful than using `.isSameNode` checks.